### PR TITLE
chore(test): use SQLite + doctrine:schema for test fixtures

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,6 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
-#DATABASE_URL="sqlite:///%kernel.project_dir%/var/test.db"
+DATABASE_URL="sqlite:///%kernel.project_dir%/var/test.db"
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther

--- a/Makefile
+++ b/Makefile
@@ -137,10 +137,11 @@ list-backups: ## List all available backups
 	@ls -lah var/*.sql 2>/dev/null || echo "No backup files found"
 
 ## —— Tests ✅ —————————————————————————————————————————————————————————————————
-test-load-fixtures: ## load database schema & fixtures
+test-load-fixtures: ## load database schema & fixtures (SQLite + doctrine:schema)
 	$(DOCKER_TEST_EXEC) php bin/console doctrine:database:drop --if-exists --force
 	$(DOCKER_TEST_EXEC) php bin/console doctrine:database:create --if-not-exists
-	$(DOCKER_TEST_EXEC) php bin/console doctrine:migration:migrate -n --no-all-or-nothing
+	$(DOCKER_TEST_EXEC) php bin/console doctrine:schema:drop --full-database --force
+	$(DOCKER_TEST_EXEC) php bin/console doctrine:schema:create -n
 	$(DOCKER_TEST_EXEC) php bin/console doctrine:fixtures:load -n
 
 test: phpunit.xml.dist ## Launch main functional and unit tests, stopped on failure

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -38,9 +38,9 @@ doctrine:
 when@test:
     doctrine:
         dbal:
+            driver: 'pdo_sqlite'
+            url: '%env(resolve:DATABASE_URL)%'
             use_savepoints: true
-            # "TEST_TOKEN" is typically set by ParaTest
-            dbname_suffix: "_test%env(default::TEST_TOKEN)%"
 
 when@prod:
     doctrine:


### PR DESCRIPTION
This PR updates the test setup to be faster and DB-agnostic.

Changes
- Enable SQLite in .env.test (file-backed: var/test.db)
- Configure Doctrine (when@test) to use pdo_sqlite and DATABASE_URL
- Update Makefile target test-load-fixtures to use doctrine:schema (drop/create) instead of migrations, then load fixtures

Why
- Avoid MySQL dependency in tests
- Speed up CI and local tests
- Prevent migration drift impacting tests

Notes
- Dev/prod remain on MySQL as configured
- For in-memory SQLite, multiple console calls make it impractical; file DB is used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Switched test environment to SQLite with a dedicated test database URL.
  - Replaced migration-based setup with full schema rebuild before loading fixtures for more reliable, repeatable tests.
  - Removed per-process test database suffix mechanism.

- Chores
  - Updated test fixtures loading task description to reflect the new SQLite + schema workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->