### PR TITLE
fix: resolve Doctrine ORM deprecation warnings for ORM 3.0 compatibility (#11)

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -2,7 +2,7 @@ doctrine:
     dbal:
         # configure these for your database server
         driver: "pdo_mysql"
-        server_version: "8"
+        server_version: "8.0.31"
         charset: utf8mb4
         default_table_options:
             charset: utf8mb4
@@ -11,6 +11,7 @@ doctrine:
         url: "%env(resolve:DATABASE_URL)%"
     orm:
         auto_generate_proxy_classes: true
+        enable_lazy_ghost_objects: true
         entity_managers:
             default:
                 quote_strategy: doctrine.orm.quote_strategy.ansi
@@ -23,6 +24,7 @@ doctrine:
                         dir: "%kernel.project_dir%/src/Entity"
                         prefix: 'App\Entity'
                         alias: App
+                report_fields_where_declared: true
                 dql:
                     string_functions:
                         if: DoctrineExtensions\Query\Mysql\IfElse


### PR DESCRIPTION
## Summary

Fixes three Doctrine ORM deprecation warnings to prepare for ORM 3.0 compatibility. These are configuration-only changes that maintain backward compatibility while addressing future breaking changes.

## Deprecation Warnings Resolved

### 1. MySQL Version Detection ✅
**Problem**: `Version detection logic for MySQL will change in DBAL 4`
**Solution**: Changed `server_version: "8"` to `server_version: "8.0.31"`
**Impact**: Prevents version detection issues in DBAL 4.0

### 2. Lazy Ghost Objects ✅  
**Problem**: `Not enabling lazy ghost objects is deprecated and will not be supported in Doctrine ORM 3.0`
**Solution**: Added `enable_lazy_ghost_objects: true`
**Impact**: Required for ORM 3.0, improves lazy loading performance

### 3. AttributeDriver Field Reporting ✅
**Problem**: `In ORM 3.0, the AttributeDriver will report fields for the classes where they are declared`  
**Solution**: Added `report_fields_where_declared: true`
**Impact**: Enables new ORM 3.0 field reporting mode, may reveal invalid mappings

## Technical Details

### Configuration Changes in `config/packages/doctrine.yaml`:

```yaml
doctrine:
    dbal:
        server_version: "8.0.31"  # Was "8"
    orm:
        enable_lazy_ghost_objects: true  # NEW
        entity_managers:
            default:
                report_fields_where_declared: true  # NEW
```

## Benefits

- **Future Compatibility**: Prepares application for Doctrine ORM 3.0 upgrade
- **Performance**: Lazy ghost objects provide better memory usage and performance
- **Code Quality**: New field reporting may uncover mapping configuration issues
- **No Breaking Changes**: All changes maintain backward compatibility

## Risk Assessment

- **Risk Level**: Very Low
- **Configuration Only**: No code changes, only YAML configuration
- **Backward Compatible**: All settings work with current ORM version
- **Reversible**: Changes can be easily reverted if issues arise

## Testing

- [x] **PHPStan Analysis**: ✅ No errors
- [x] **Configuration Syntax**: ✅ Valid YAML structure
- [x] **Pre-commit Hooks**: ✅ All validations pass
- [x] **Schema Validation**: ✅ Doctrine configuration accepted

## Validation

The configuration changes are purely additive and enable recommended settings for ORM 3.0 compatibility:

| Setting | Current ORM | ORM 3.0 | Compatibility |
|---------|-------------|---------|---------------|
| `server_version: "8.0.31"` | ✅ Works | ✅ Required | ✅ Compatible |
| `enable_lazy_ghost_objects: true` | ✅ Works | ✅ Required | ✅ Compatible |
| `report_fields_where_declared: true` | ✅ Works | ✅ Default | ✅ Compatible |

## References

- [Doctrine ORM 3.0 Upgrade Guide](https://github.com/doctrine/orm/blob/3.0.x/UPGRADE.md)
- [AttributeDriver PR #10455](https://github.com/doctrine/orm/pull/10455)
- [Lazy Ghost Objects PR #10837](https://github.com/doctrine/orm/pull/10837)
- [DBAL MySQL Version Detection](https://github.com/doctrine/dbal/pull/5779)

Closes #11