### PR TITLE
fix: display period name instead of object in header dropdown (#33)

### DIFF
--- a/templates/_inspina/includes/header_periods.html.twig
+++ b/templates/_inspina/includes/header_periods.html.twig
@@ -2,7 +2,7 @@
 
 <li class="dropdown">
     <a class="dropdown-toggle count-info" data-toggle="dropdown" href="#">
-        <em class="fa fa-calendar"></em> {{ app.session.get('period').selected|default(null) }}
+        <em class="fa fa-calendar"></em> {{ app.session.get('period').selected.name|default('header.periods.none_selected'|trans) }}
     </a>
     <ul class="dropdown-menu dropdown-alerts">
         {% for period in app.session.get('period').list|default({}) %}

--- a/translations/layout.fr.yaml
+++ b/translations/layout.fr.yaml
@@ -9,6 +9,7 @@ top.logout: Déconnexion
 top.welcome: 'Bienvenue sur l''admin'
 top.search: 'Recherche global...'
 header.periods.notfound: 'Aucune période disponible'
+header.periods.none_selected: 'Aucune période sélectionnée'
 search.btn: Rechercher
 search.placehoder: 'Votre recherche...'
 base.not_body.title: 'Page en cours de construction...'


### PR DESCRIPTION
## Summary
Fix the period dropdown in the header navigation that currently displays the raw Period object instead of the period name, resolving poor user experience and unclear period selection.

## Problem Solved
- **Before**: Header period dropdown showed object representation instead of human-readable period name
- **After**: Shows clear, readable period name with proper fallback when no period is selected

## Changes Made
- Updated `templates/_inspina/includes/header_periods.html.twig` to access `.name` property instead of displaying raw object
- Added proper translation fallback `header.periods.none_selected` for when no period is selected
- Added French translation key to `translations/layout.fr.yaml`

## Root Cause Analysis
The issue was in line 5 of the header template where `app.session.get('period').selected` returned the Period entity object without accessing its `name` property.

## Technical Details
- **Fixed**: `{{ app.session.get('period').selected|default(null) }}`
- **To**: `{{ app.session.get('period').selected.name|default('header.periods.none_selected'|trans) }}`

## Testing
- [x] All existing tests pass
- [x] Code analysis tools pass (PHPStan, PHP CS Fixer, Rector)
- [x] Translation key properly added
- [x] Fallback behavior works correctly

## Impact
- **User Experience**: Period dropdown now displays readable period names
- **Consistency**: Matches pattern used in other templates (e.g., Tailwind header)
- **Internationalization**: Proper French translation for fallback text

Closes #33